### PR TITLE
Fixing WAD Event Hub plugin jar dependency problem; and a few other issues.

### DIFF
--- a/Logstash/logstash-input-azurewadeventhub/CHANGELOG.md
+++ b/Logstash/logstash-input-azurewadeventhub/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 2016.04.28
+* Fixed the jar dependency problem. Now installing the plugin by using the "plugin" or "logstash-plugin" (for newer versions of Logstash) should automatically download and jar files needed.
+* Added missing json runtime dependency.
+* Fixed the default value of *time_since_epoch_millis* to use UTC time to match the SelectorFilter.
+* Made the plugin to respect Logstash shutdown signal.
+* Updated the *logstash-core* runtime dependency requirement to '~> 2.0'.
+* Updated the *logstash-devutils* development dependency requirement to '>= 0.0.16'

--- a/Logstash/logstash-input-azurewadeventhub/Gemfile
+++ b/Logstash/logstash-input-azurewadeventhub/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-gem 'azure', '~> 0.7.1'

--- a/Logstash/logstash-input-azurewadeventhub/README.md
+++ b/Logstash/logstash-input-azurewadeventhub/README.md
@@ -1,91 +1,80 @@
-# Notice
-This plugin is a part of [Microsoft Azure Diagnostics with ELK](https://github.com/Azure/azure-diagnostics-tools).
+# Logstash input plugin for Azure diagnostics data from Event Hubs 
 
-[See more documentation.](https://github.com/mspnp/semantic-logging/blob/v3/ELK/md/LogstashExtensions.md#azure-wad-table)
+## Summary
+This plugin reads Azure diagnostics data from specified Azure Event Hubs and parses the data for output.
 
-# Logstash Plugin
-
-This is a plugin for [Logstash](https://github.com/elasticsearch/logstash).
-
-It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
-
-## Documentation
-
-Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elasticsearch.org/guide/en/logstash/current/).
-
-- For formatting code or config example, you can use the asciidoc `[source,ruby]` directive
-- For more asciidoc formatting tips, see the excellent reference here https://github.com/elasticsearch/docs#asciidoc-guide
-
-## Need Help?
-
-Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/logstash discussion forum.
-
-## Developing
-
-### 1. Plugin Developement and Testing
-
-#### Code
-- To get started, you'll need JRuby with the Bundler gem installed.
-
-- Create a new plugin or clone and existing from the GitHub [logstash-plugins](https://github.com/logstash-plugins) organization. We also provide [example plugins](https://github.com/logstash-plugins?query=example).
-
-- Install dependencies
+## Installation
+You can install this plugin using the Logstash "plugin" or "logstash-plugin" (for newer versions of Logstash) command:
 ```sh
-bundle install
+logstash-plugin install logstash-input-azurewadeventhub
 ```
+For more information, see Logstash reference [Working with plugins](https://www.elastic.co/guide/en/logstash/current/working-with-plugins.html).
 
-#### Test
+## Configuration
+### Required Parameters
+*key*
 
-- Update your dependencies
+The shared access key to the target event hub.
 
-```sh
-bundle install
-```
+*username*
 
-- Run tests
+The name of the shared access policy.
 
-```sh
-bundle exec rspec
-```
+*namespace*
 
-### 2. Running your unpublished Plugin in Logstash
+Event Hub namespace.
 
-#### 2.1 Run in a local Logstash clone
+*eventhub*
 
-- Edit Logstash `Gemfile` and add the local plugin path, for example:
+Event Hub name.
+
+*partitions*
+
+Partition count of the target event hub.
+
+### Optional Parameters
+*domain*
+
+Domain of the target Event Hub. Default value is "servicebus.windows.net".
+
+*port*
+
+Port of the target Event Hub. Default value is 5671.
+
+*receive_credits*
+
+The credit number to limit the number of messages to receive in a processing cycle. Default value is 1000.
+
+*consumer_group*
+
+Name of the consumer group. Default value is "$default".
+
+*time_since_epoch_millis*
+
+Specifies the point of time after which the messages are received. Default value is the time when this plugin is initialized:
 ```ruby
-gem "logstash-filter-awesome", :path => "/your/local/logstash-filter-awesome"
+Time.now.utc.to_i * 1000
 ```
-- Install plugin
-```sh
-bin/plugin install --no-verify
+*thread_wait_sec*
+
+Specifies the time (in seconds) to wait before another try if no message was received.
+
+### Examples
+```json
+input
+{
+    azurewadeventhub
+    {
+        key => "VGhpcyBpcyBhIGZha2Uga2V5Lg=="
+        username => "receivepolicy"
+        namespace => "mysbns"
+        eventhub => "myeventhub"
+        partitions => 4
+    }
+}
 ```
-- Run Logstash with your plugin
-```sh
-bin/logstash -e 'filter {awesome {}}'
-```
-At this point any modifications to the plugin code will be applied to this local Logstash setup. After modifying the plugin, simply rerun Logstash.
 
-#### 2.2 Run in an installed Logstash
+## More information
+The source code of this plugin is hosted in GitHub repo [Microsoft Azure Diagnostics with ELK](https://github.com/Azure/azure-diagnostics-tools). We welcome you to provide feedback and/or contribute to the project.
 
-You can use the same **2.1** method to run your plugin in an installed Logstash by editing its `Gemfile` and pointing the `:path` to your local plugin development directory or you can build the gem and install it using:
-
-- Build your plugin gem
-```sh
-gem build logstash-filter-awesome.gemspec
-```
-- Install the plugin from the Logstash home
-```sh
-bin/plugin install /your/local/plugin/logstash-filter-awesome.gem
-```
-- Start Logstash and proceed to test the plugin
-
-## Contributing
-
-All contributions are welcome: ideas, patches, documentation, bug reports, complaints, and even something you drew up on a napkin.
-
-Programming is not a required skill. Whatever you've seen about open source and maintainers or community members  saying "send patches or die" - you will not see that here.
-
-It is more important to the community that you are able to contribute.
-
-For more information about contributing, see the [CONTRIBUTING](https://github.com/elasticsearch/logstash/blob/master/CONTRIBUTING.md) file.
+Please also see [Analyze Diagnostics Data with ELK template](https://github.com/Azure/azure-quickstart-templates/tree/master/diagnostics-with-elk) for quick deployment of ELK to Azure.   

--- a/Logstash/logstash-input-azurewadeventhub/logstash-input-azurewadeventhub.gemspec
+++ b/Logstash/logstash-input-azurewadeventhub/logstash-input-azurewadeventhub.gemspec
@@ -1,16 +1,17 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-azurewadeventhub'
-  s.version       = '0.9.4'
+  s.version       = '0.9.7'
+  s.platform      = "java"
   s.licenses      = ['Apache License (2.0)']
   s.summary       = "This plugin will collect Microsoft Azure Diagnostics data from Azure Event Hubs."
-  s.description   = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program."
+  s.description   = "This gem is a Logstash plugin. It reads and parses diagnostics data from Azure Event Hubs."
   s.authors       = ["Microsoft Corporation"]
   s.email         = 'azdiag@microsoft.com'
   s.homepage      = "https://github.com/Azure/azure-diagnostics-tools"
   s.require_paths = ["lib"]
 
   # Files
-  s.files = `git ls-files`.split($\)
+  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','Gemfile','LICENSE']
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
@@ -18,14 +19,15 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '>= 1.4.0'
+  s.add_runtime_dependency 'logstash-core', '~> 2.0'
   s.add_runtime_dependency 'azure', '~> 0.7.1'
-  s.add_development_dependency 'logstash-devutils'
+  s.add_runtime_dependency 'json', '~> 1.8.3'
+  s.add_development_dependency 'logstash-devutils', '>= 0.0.16'
   
   #Jar dependencies
   s.requirements << "jar 'org.apache.qpid:qpid-amqp-1-0-common', '0.32'"
   s.requirements << "jar 'org.apache.qpid:qpid-amqp-1-0-client-jms', '0.32'"
   s.requirements << "jar 'org.apache.qpid:qpid-client', '0.32'"
   s.requirements << "jar 'org.apache.geronimo.specs:geronimo-jms_1.1_spec', '1.1.1'"
-  s.add_runtime_dependency 'jar-dependencies'
+  s.add_runtime_dependency 'jar-dependencies', '~> 0.3.2'
 end


### PR DESCRIPTION
## 2016.04.28
* Fixed the jar dependency problem. Now installing the plugin by using the "plugin" or "logstash-plugin" (for newer versions of Logstash) should automatically download and jar files needed.
* Added missing json runtime dependency.
* Fixed the default value of *time_since_epoch_millis* to use UTC time to match the SelectorFilter.
* Made the plugin to respect Logstash shutdown signal.
* Updated the *logstash-core* runtime dependency requirement to '~> 2.0'.
* Updated the *logstash-devutils* development dependency requirement to '>= 0.0.16'