### PR TITLE
Require "time" to use iso8601

### DIFF
--- a/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
+++ b/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require "logstash/inputs/base"
 require "logstash/namespace"
-
+require "time"
 require "azure"
 
 class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base


### PR DESCRIPTION
This is to fix errors like this one appearing in the logs :  
{:timestamp=>"2016-09-07T08:46:16.831000+0000", :message=>"A plugin had an unrecoverable error. Will restart this plugin.\n  Plugin: <LogStash::Inputs::AzureWADTable account_name=>\"...\", access_key=>\"...", table_name=>\"...\", codec=><LogStash::Codecs::Plain charset=>\"UTF-8\">, entity_count_to_process=>100, collection_start_time_utc=>\"2016-08-29T09:39:42Z\", etw_pretty_print=>false, idle_delay_seconds=>15, endpoint=>\"core.windows.net\", data_latency_minutes=>1>\n  Error: undefined method `iso8601' for nil:NilClass", :level=>:error}