### PR TITLE
Cleaning required for parsing iothub logs

### DIFF
--- a/Logstash/logstash-input-azureeventhub/lib/logstash/inputs/azureeventhub.rb
+++ b/Logstash/logstash-input-azureeventhub/lib/logstash/inputs/azureeventhub.rb
@@ -43,7 +43,7 @@ class LogStash::Inputs::Azureeventhub < LogStash::Inputs::Base
     return nil if not message
     message.getPayload().each do |section|
       if section.java_kind_of? org::apache::qpid::amqp_1_0::type::messaging::Data or section.java_kind_of? org::apache::qpid::amqp_1_0::type::messaging::AmqpValue
-        return section.getValue().to_s
+        return section.getValue().to_s.gsub("\\x5c", "\\")
       end
     end
     return nil


### PR DESCRIPTION
Hello,
Sending this as a pull request but probably not the correct way to fix this. I was trying to parse the iothub monitoring logs and got following exception: 

{:timestamp=>"2016-09-13T14:25:40.836000+0000", :message=>"JSON parse failure. Falling back to plain-text", :error=>#<LogStash::Json::ParserError: Unrecognized character escape 'x' (code 120)
 at [Source: [B@52fa4a1; line: 1, column: 36]>, :data=>"{\"protocol\":\"Amqp\",\"authType\":\"{ \x5c\"scope\x5c\": \x5c\"device\x5c\", \x5c\"type\x5c\": \x5c\"sas\x5c\", \x5c\"issuer\x5c\": \x5c\"iothub\x5c\" }\",\"time\":\"2016-09-13T03:24:24.1641762Z\",\"operationName\":\"deviceConnect\",\"category\":\"Connections\",\"level\":\"Information\",\"deviceId\":\"mydevice\"}", :level=>:info}

Tried using a mutate filter with following conf : 

mutate {
gsub [ "authType", "\\x5c", "\\"]
}

This doesn't work as it seem to fail before getting to the filter. With the proposed code change, I can parse them properly.
