### PR TITLE
Converting PreciseTimestamp to Logstash Time

### DIFF
--- a/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
+++ b/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
@@ -119,6 +119,9 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
           end
         end
         decorate(event)
+        if event['PreciseTimeStamp'].is_a?(Time)
+          event['PreciseTimeStamp']=LogStash::Timestamp.new(event['PreciseTimeStamp'])
+        end
         output_queue << event
         if (!event["TIMESTAMP"].nil?)
           last_good_timestamp = event["TIMESTAMP"]


### PR DESCRIPTION
This allows to use the PreciseTimestamp field directly as the timestamp field without converting it to string and then parsing it with the date filter.