### PR TITLE
Logstash 5.0 support for logstash-input-azurewadtable

### DIFF
--- a/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
+++ b/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
@@ -93,13 +93,13 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
       last_good_timestamp = nil
       result.each do |entity|
         event = LogStash::Event.new(entity.properties)
-        event["type"] = @table_name
+        event.set("type", @table_name)
 
         # Help pretty print etw files
-        if (@etw_pretty_print && !event["EventMessage"].nil? && !event["Message"].nil?)
+        if (@etw_pretty_print && !event.get("EventMessage").nil? && !event.get("Message").nil?)
           @logger.debug("event: " + event.to_s)
-          eventMessage = event["EventMessage"].to_s
-          message = event["Message"].to_s
+          eventMessage = event.get("EventMessage").to_s
+          message = event.get("Message").to_s
           @logger.debug("EventMessage: " + eventMessage)
           @logger.debug("Message: " + message)
           if (eventMessage.include? "%")
@@ -114,17 +114,17 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
               @logger.debug("New Value: " + newValue)
               eventMessage[key] = newValue
             end # do block
-            event["EventMessage"] = eventMessage
-            @logger.debug("pretty print end. result: " + event["EventMessage"].to_s)
+            event.set("EventMessage", eventMessage)
+            @logger.debug("pretty print end. result: " + event.get("EventMessage").to_s)
           end
         end
         decorate(event)
-        if event['PreciseTimeStamp'].is_a?(Time)
-          event['PreciseTimeStamp']=LogStash::Timestamp.new(event['PreciseTimeStamp'])
+        if event.get('PreciseTimeStamp').is_a?(Time)
+          event.set('PreciseTimeStamp', LogStash::Timestamp.new(event.get('PreciseTimeStamp')))
         end
         output_queue << event
-        if (!event["TIMESTAMP"].nil?)
-          last_good_timestamp = event["TIMESTAMP"]
+        if (!event.get("TIMESTAMP").nil?)
+          last_good_timestamp = event.get("TIMESTAMP")
         end
       end # each block
       @idle_delay = 0

--- a/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
+++ b/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
@@ -9,7 +9,7 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
 
   config_name "azurewadtable"
   milestone 1
-  
+
   config :account_name, :validate => :string
   config :access_key, :validate => :string
   config :table_name, :validate => :string
@@ -41,7 +41,7 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
     @idle_delay = @idle_delay_seconds
     @continuation_token = nil
   end # register
-  
+
   public
   def run(output_queue)
     while !stop?
@@ -51,10 +51,10 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
       sleep @idle_delay
     end # while
   end # run
- 
+
   public
   def teardown
-  end  
+  end
 
   def build_latent_query
     @logger.debug("from #{@last_timestamp} to #{@until_timestamp}")
@@ -107,7 +107,7 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
             toReplace = eventMessage.scan(/%\d+/)
             payload = message.scan(/(?<!\\S)([a-zA-Z]+)=(\"[^\"]*\")(?!\\S)/)
             # Split up the format string to seperate all of the numbers
-            toReplace.each do |key| 
+            toReplace.each do |key|
               @logger.debug("Replacing key: " + key.to_s)
               index = key.scan(/\d+/).join.to_i
               newValue = payload[index - 1][1]
@@ -135,7 +135,7 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
       @logger.debug("No new results found.")
       @idle_delay = @idle_delay_seconds
     end # if block
-    
+
   rescue => e
     @logger.error("Oh My, An error occurred.", :exception => e)
     raise
@@ -157,11 +157,11 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
     ticks = to_ticks(collection_time)
     "0#{ticks}"
   end # partitionkey_from_datetime
-  
+
   # Convert time to ticks
   def to_ticks(time_to_convert)
     @logger.debug("Converting time to ticks")
-    time_to_convert.to_i * 10000000 - TICKS_SINCE_EPOCH 
+    time_to_convert.to_i * 10000000 - TICKS_SINCE_EPOCH
   end # to_ticks
 
 end # LogStash::Inputs::AzureWADTable

--- a/Logstash/logstash-input-azurewadtable/logstash-input-azurewadtable.gemspec
+++ b/Logstash/logstash-input-azurewadtable/logstash-input-azurewadtable.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '~> 2.0'
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'azure', '~> 0.7.3'
-  s.add_development_dependency 'logstash-devutils', '>= 0.0.16'
+  s.add_development_dependency 'logstash-devutils', '>= 1.1.0'
 end
 


### PR DESCRIPTION
Logstash 5.0.0 [changed the Event API](https://github.com/elastic/logstash/issues/5141) for plugins.

The `s.version` line in `logstash-input-azurewadtable.gemspec` should probably also be changed according to this project's preferred versioning system.

It may also be appropriate to branch/tag the current version of this plugin to continue to provide support for users of previous Logstash versions.