### PR TITLE
Move the continuation token out side the loop.

### DIFF
--- a/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
+++ b/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
@@ -36,8 +36,8 @@ class LogStash::Inputs::Azureblob < LogStash::Inputs::Base
   
   def list_blob_names
     blob_names = Set.new []
+    continuation_token = NIL
     loop do
-      continuation_token = NIL
       entries = @azure_blob.list_blobs(@container, { :timeout => 10, :marker => continuation_token})
       entries.each do |entry|
         blob_names << entry.name


### PR DESCRIPTION
Move the initialization of the continuation token out side the loop.  As written the list_blobs() method would always return the first page of results.  So if the container has more that the default number of entries (5000) then it will just continue to loop.  
