### PR TITLE
Fix plugin dependencies versions to work with Logstash 5+.

### DIFF
--- a/Logstash/logstash-input-azureblob/logstash-input-azureblob.gemspec
+++ b/Logstash/logstash-input-azureblob/logstash-input-azureblob.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '~> 2.0'
+  s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
   s.add_runtime_dependency 'azure', '~> 0.7.1'
-  s.add_development_dependency 'logstash-devutils', '>= 0.0.16'
+  s.add_development_dependency 'logstash-devutils'
 end

--- a/Logstash/logstash-input-azuretopic/logstash-input-azuretopic.gemspec
+++ b/Logstash/logstash-input-azuretopic/logstash-input-azuretopic.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '~> 2.0'
+  s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
   s.add_runtime_dependency 'azure', '~> 0.7.1'
-  s.add_development_dependency 'logstash-devutils', '>= 0.0.16'
+  s.add_development_dependency 'logstash-devutils'
 end

--- a/Logstash/logstash-input-azuretopicthreadable/logstash-input-azuretopicthreadable.gemspec
+++ b/Logstash/logstash-input-azuretopicthreadable/logstash-input-azuretopicthreadable.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '~> 2.0'
+  s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
   s.add_runtime_dependency 'azure', '~> 0.7.1'
-  s.add_development_dependency 'logstash-devutils', '>= 0.0.16'
+  s.add_development_dependency 'logstash-devutils'
 end

--- a/Logstash/logstash-output-applicationinsights/logstash-output-applicationinsights.gemspec
+++ b/Logstash/logstash-output-applicationinsights/logstash-output-applicationinsights.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency 'logstash-core', '~> 2.0'
+  s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
   s.add_runtime_dependency 'application_insights', '~> 0.5.3'
-  s.add_development_dependency 'logstash-devutils', '>= 0.0.16'
+  s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
- Azure Blob
- Azure Topic
- Azure Topic Threadable
- ApplicationInsights

More information can be found: [#46](https://github.com/Azure/azure-diagnostics-tools/issues/46) and [#62](https://github.com/Azure/azure-diagnostics-tools/issues/62).