### PR TITLE
Fix issue #86

### DIFF
--- a/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
+++ b/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
@@ -231,6 +231,7 @@ def get_jsons!(content, batch_size)
     else
       index = [inIndex, outIndex].min
     end #if
+
     if content[index] == '{'
       count += 1
       move_opening = true
@@ -241,6 +242,10 @@ def get_jsons!(content, batch_size)
       move_opening = false
     end #if
     index += 1
+
+    if (count < 0) 
+      throw "Malformed json encountered."
+    end #if
     hit += 1 if count == 0
   end
   # slice left & then right to making sure the leading characters are trimed.

--- a/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
+++ b/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
@@ -155,26 +155,26 @@ class LogStash::Inputs::LogstashInputAzureblob < LogStash::Inputs::Base
           blob, content = @azure_blob.get_blob(@container, blob_name, {:start_range => start_index} )
 
           # content will be used to calculate the new offset. Create a new variable for processed content.
-          processed_content = content
+          content_length = content.length unless content.nil?
 
           is_json_codec = (defined?(LogStash::Codecs::JSON) == 'constant') && (@codec.is_a? LogStash::Codecs::JSON)
           if (is_json_codec)
-            skip = processed_content.index '{'
-            processed_content.slice!(skip-1) unless (skip.nil? || skip == 0)
+            skip = content.index '{'
+            content.slice!(skip-1) unless (skip.nil? || skip == 0)
           end #if
 
           if is_json_codec && (@break_json_down_policy != 'do_not_break')
             @logger.debug("codec is json and policy is not do_not_break")
             
-            @break_json_batch_count = 1 if break_json_batch_count <= 0
-            tail = processed_content[-@file_tail_bytes..-1]
-            while (!processed_content.nil? && processed_content.length > @file_tail_bytes)
-              json_event = get_jsons!(processed_content, @break_json_batch_count)
+            @break_json_batch_count = 1 if @break_json_batch_count <= 0
+            tail = content[-@file_tail_bytes..-1]
+            while (!content.nil? && content.length > @file_tail_bytes)
+              json_event = get_jsons!(content, @break_json_batch_count)
+              break if json_event.nil?
               @logger.debug("Got json: ========================")
               @logger.debug("#{json_event[0..50]}...#{json_event[-50..-1]}")
               @logger.debug("End got json: ========================")
-              @logger.debug("Processed content: #{processed_content[0..50]}...")
-              break if json_event.nil?
+              @logger.debug("Processed content: #{content[0..50]}...")
               if @break_json_down_policy == 'with_head_tail'
                 @logger.debug("Adding json head/tails.")
                 json_event = "#{header}#{json_event}#{tail}"
@@ -187,8 +187,8 @@ class LogStash::Inputs::LogstashInputAzureblob < LogStash::Inputs::Base
           else
             @logger.debug("Non-json codec or the policy is do not break")
             # Putting header and content and tail together before pushing into event queue
-            processed_content = "#{header}#{processed_content}" unless header.nil? || header.length == 0
-            @codec.decode(processed_content) do |event|
+            content = "#{header}#{content}" unless header.nil? || header.length == 0
+            @codec.decode(content) do |event|
               decorate(event)
               queue << event
             end # decode
@@ -197,7 +197,7 @@ class LogStash::Inputs::LogstashInputAzureblob < LogStash::Inputs::Base
           # Making sure the reader is removed from the registry even when there's exception.
           new_offset = start_index
           new_offset = 0 if start_index == @file_head_bytes && content.nil? # Reset the offset when nothing has been read.
-          new_offset = new_offset + content.length unless content.nil?
+          new_offset = new_offset + content_length unless content_length.nil?
           new_registry_item = LogStash::Inputs::RegistryItem.new(blob_name, new_etag, nil, new_offset, gen)
           update_registry(new_registry_item)
         end # begin
@@ -207,46 +207,47 @@ class LogStash::Inputs::LogstashInputAzureblob < LogStash::Inputs::Base
     end # begin
   end # process
   
-  # Get first json object out of a string and return it. Note, content will be updated in place as well.
-  def get_jsons!(content, batch_size)
-    return nil, content, 0 if content.nil? || content.length == 0
-    return nil, content, 0 if (content.index '{').nil?
+# Get json objects out of a string and return it. Note, content will be updated in place as well.
+def get_jsons!(content, batch_size)
+  return nil if content.nil? || content.length == 0
+  return nil if (content.index '{').nil?
 
-    hit = 0
-    count = 0
-    index = 0
-    first = content.index('{')
-    move_opening = true
-    move_closing = true
-    while(hit < batch_size)
-        inIndex = content.index('{', index) if move_opening
-        outIndex = content.index('}', index) if move_closing
+  hit = 0
+  count = 0
+  index = 0
+  first = content.index('{')
+  move_opening = true
+  move_closing = true
+  while(hit < batch_size)
+      inIndex = content.index('{', index) if move_opening
+      outIndex = content.index('}', index) if move_closing
 
-        # TODO: Fix the ending condition
-        break if count == 0 && (inIndex.nil? || outIndex.nil?)
-        
-        if(inIndex.nil?)
-            index = outIndex
-        elsif(outIndex.nil?)
-            index = inIndex
-        else
-            index = [inIndex, outIndex].min
-        end #if
-        if content[index] == '{'
-            count += 1
-            move_opening = true
-            move_closing = false
-        elsif content[index] == '}'
-            count -= 1
-            move_closing = true
-            move_opening = false
-        end #if
-        index += 1
-        hit += 1 if count == 0
-    end
-    
-    return content.slice!(first..index-1), hit
-  end #def get_first_json
+      # TODO: Fix the ending condition
+      break if count == 0 && (inIndex.nil? || outIndex.nil?)
+      
+      if(inIndex.nil?)
+          index = outIndex
+      elsif(outIndex.nil?)
+          index = inIndex
+      else
+          index = [inIndex, outIndex].min
+      end #if
+      if content[index] == '{'
+          count += 1
+          move_opening = true
+          move_closing = false
+      elsif content[index] == '}'
+          count -= 1
+          move_closing = true
+          move_opening = false
+      end #if
+      index += 1
+      hit += 1 if count == 0
+  end
+  # slice left & then right to making sure the leading characters are trimed.
+  content.slice!(0, first) if first > 0
+  return content.slice!(0, index-first)
+end #def get_jsons!
 
   # Deserialize registry hash from json string.
   def deserialize_registry_hash (json_string)

--- a/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
+++ b/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
@@ -219,30 +219,29 @@ def get_jsons!(content, batch_size)
   move_opening = true
   move_closing = true
   while(hit < batch_size)
-      inIndex = content.index('{', index) if move_opening
-      outIndex = content.index('}', index) if move_closing
+    inIndex = content.index('{', index) if move_opening
+    outIndex = content.index('}', index) if move_closing
 
-      # TODO: Fix the ending condition
-      break if count == 0 && (inIndex.nil? || outIndex.nil?)
-      
-      if(inIndex.nil?)
-          index = outIndex
-      elsif(outIndex.nil?)
-          index = inIndex
-      else
-          index = [inIndex, outIndex].min
-      end #if
-      if content[index] == '{'
-          count += 1
-          move_opening = true
-          move_closing = false
-      elsif content[index] == '}'
-          count -= 1
-          move_closing = true
-          move_opening = false
-      end #if
-      index += 1
-      hit += 1 if count == 0
+    break if count == 0 && (inIndex.nil? || outIndex.nil?)
+    
+    if(inIndex.nil?)
+      index = outIndex
+    elsif(outIndex.nil?)
+      index = inIndex
+    else
+      index = [inIndex, outIndex].min
+    end #if
+    if content[index] == '{'
+      count += 1
+      move_opening = true
+      move_closing = false
+    elsif content[index] == '}'
+      count -= 1
+      move_closing = true
+      move_opening = false
+    end #if
+    index += 1
+    hit += 1 if count == 0
   end
   # slice left & then right to making sure the leading characters are trimed.
   content.slice!(0, first) if first > 0

--- a/Logstash/logstash-input-azureblob/logstash-input-azureblob.gemspec
+++ b/Logstash/logstash-input-azureblob/logstash-input-azureblob.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-azureblob'
-  s.version       = '0.9.9'
+  s.version       = '0.9.10'
   s.licenses      = ['Apache License (2.0)']
   s.summary       = 'This plugin collects Microsoft Azure Diagnostics data from Azure Storage Blobs.'
   s.description   = 'This gem is a Logstash plugin. It reads and parses data from Azure Storage Blobs.'


### PR DESCRIPTION
Fix for #86. Speed up function to parse json. 85 times faster gain for the get_jsons method by simple benchmark.

Details:
Bench mark:
10000 iterations, 0.350833 / 0.004146 = 84.619633. (~85 times faster).
Details:

  Start of content (New)
  {"time":"2017-08-24T21:00:23.5420000Z","systemId":"e22a0996-e5a7-4952-8e28-4357a6e8f0c5","category":"
  0.010000   0.000000   0.010000 (  0.004146)

  saars@DESKTOP-F8RTJFM:/mnt/d/Ruby/azure-ruby$ ruby getjson.2.rb
  Start of content (Benchmark)
  {"time":"2017-08-24T21:00:23.5420000Z","systemId":"e22a0996-e5a7-4952-8e28-4357a6e8f0c5","category":"
  0.350000   0.000000   0.350000 (  0.350833)