### PR TITLE
Fix logstash-input-azureeventhub

### DIFF
--- a/Logstash/logstash-input-azureeventhub/lib/logstash/inputs/azureeventhub.rb
+++ b/Logstash/logstash-input-azureeventhub/lib/logstash/inputs/azureeventhub.rb
@@ -60,9 +60,9 @@ class LogStash::Inputs::Azureeventhub < LogStash::Inputs::Base
         if msg
           body, annotationMap = get_pay_load(msg)
           last_event_offset = annotationMap.get(org::apache::qpid::amqp_1_0::type::Symbol.valueOf("x-opt-offset")) unless annotationMap.nil?
-          @logger.debug("[#{partition.to_s.rjust(2,"0")}] Event: #{body[0..50] unless body.nil?}... " +
-            "Offset: #{annotationMap.get(org::apache::qpid::amqp_1_0::type::Symbol.valueOf("x-opt-offset")) unless annotationMap.nil? } " +
-            "Time: #{annotationMap.get(org::apache::qpid::amqp_1_0::type::Symbol.valueOf("x-opt-enqueued-time")).to_s unless annotationMap.nil? } " +
+          @logger.debug("[#{partition.to_s.rjust(2,"0")}] Event: #{body[0..50] unless body.nil?}... " <<
+            "Offset: #{annotationMap.get(org::apache::qpid::amqp_1_0::type::Symbol.valueOf("x-opt-offset")) unless annotationMap.nil? } " <<
+            "Time: #{annotationMap.get(org::apache::qpid::amqp_1_0::type::Symbol.valueOf("x-opt-enqueued-time")).to_s unless annotationMap.nil? } " <<
             "Sequence: #{annotationMap.get(org::apache::qpid::amqp_1_0::type::Symbol.valueOf("x-opt-sequence-number")).to_s unless annotationMap.nil? }")
 
           codec.decode(body) do |event|
@@ -128,7 +128,7 @@ class LogStash::Inputs::Azureeventhub < LogStash::Inputs::Base
     raise e
   rescue => e
     @logger.error("[#{partition.to_s.rjust(2,"0")}] Oh My, An error occurred. \nError:#{e}:\nTrace:\n#{e.backtrace}", :exception => e)
-  end # process
+  end # process_partition
 
   public
   def run(output_queue)

--- a/Logstash/logstash-input-azureeventhub/logstash-input-azureeventhub.gemspec
+++ b/Logstash/logstash-input-azureeventhub/logstash-input-azureeventhub.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-azureeventhub'
-  s.version       = '0.9.7'
+  s.version       = '0.9.8'
   s.platform      = "java"
   s.licenses      = ['Apache License (2.0)']
   s.summary       = "This plugin collects data from Azure Event Hubs."


### PR DESCRIPTION
There were 2 major problems:
1. After a connection reset, the events with a timestamp older than 'now' were filtered out.
     * Now the filter is applied on the event offset, so no event is missed
2. If a second EventHub receiver starts, the logstash one stops listening.
     * Now the plugin checks for errors if there's no new event and triggers a connection reset.

#66 #45