### PR TITLE
Cache previous queries

### DIFF
--- a/Logstash/logstash-input-azurewadtable/README.md
+++ b/Logstash/logstash-input-azurewadtable/README.md
@@ -48,6 +48,9 @@ __*endpoint*__
 
 Specifies the endpoint of Azure environment. The default value is "core.windows.net".  
 
+__*past_queries_count*__
+Specifies the number of past queries to run so the plugin doesn't miss late arriving data. By default this is 5
+
 ### Examples
 ```
 input

--- a/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
+++ b/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
@@ -15,14 +15,13 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
   config :access_key, :validate => :string
   config :table_name, :validate => :string
   config :entity_count_to_process, :validate => :string, :default => 100
-  config :collection_start_time_utc, :validate => :string, :default => Time.now.utc.iso8601
+  config :collection_start_time_utc, :validate => :string, :default => nil #the actual value is set in the ctor (now - data_latency_minutes - 1)
   config :etw_pretty_print, :validate => :boolean, :default => false
   config :idle_delay_seconds, :validate => :number, :default => 15
   config :endpoint, :validate => :string, :default => "core.windows.net"
 
   # Default 1 minute delay to ensure all data is published to the table before querying.
   # See issue #23 for more: https://github.com/Azure/azure-diagnostics-tools/issues/23
-  # TODO: remove this
   config :data_latency_minutes, :validate => :number, :default => 1
 
   # Number of past queries to be run, so we don't miss late arriving data
@@ -30,8 +29,14 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
 
   TICKS_SINCE_EPOCH = Time.utc(0001, 01, 01).to_i * 10000000
 
+  INITIAL_QUERY_SPLIT_PERIOD_MINUTES = 30
+
   def initialize(*args)
     super(*args)
+    if @collection_start_time_utc.nil?
+      @collection_start_time_utc = (Time.now - ( 60 * @data_latency_minutes) - 60).iso8601
+      @logger.debug("collection_start_time_utc = #{@collection_start_time_utc}")
+    end
   end # initialize
 
   public
@@ -49,6 +54,7 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
     @last_timestamp = @collection_start_time_utc
     @idle_delay = @idle_delay_seconds
     @duplicate_detector = DuplicateDetector.new(@logger, @past_queries_count)
+    @first_run = true
   end # register
 
   public
@@ -67,78 +73,45 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
 
   def build_latent_query
     @logger.debug("from #{@last_timestamp} to #{@until_timestamp}")
+    if @last_timestamp > @until_timestamp
+      @logger.debug("last_timestamp is in the future. Will not run any query!")
+      return nil
+    end
     query_filter = "(PartitionKey gt '#{partitionkey_from_datetime(@last_timestamp)}' and PartitionKey lt '#{partitionkey_from_datetime(@until_timestamp)}')"
     for i in 0..99
       query_filter << " or (PartitionKey gt '#{i.to_s.rjust(19, '0')}___#{partitionkey_from_datetime(@last_timestamp)}' and PartitionKey lt '#{i.to_s.rjust(19, '0')}___#{partitionkey_from_datetime(@until_timestamp)}')"
     end # for block
     query_filter = query_filter.gsub('"','')
-    return query_filter, @last_timestamp.to_s << "-" << @until_timestamp.to_s
-  end
-
-  def build_zero_latency_query
-    @logger.debug("from #{@last_timestamp} to most recent data")
-    # query data using start_from_time
-    query_filter = "(PartitionKey gt '#{partitionkey_from_datetime(@last_timestamp)}')"
-    for i in 0..99
-      query_filter << " or (PartitionKey gt '#{i.to_s.rjust(19, '0')}___#{partitionkey_from_datetime(@last_timestamp)}' and PartitionKey lt '#{i.to_s.rjust(19, '0')}___9999999999999999999')"
-    end # for block
-    query_filter = query_filter.gsub('"','')
-    return query_filter, last_timestamp.to_s << "-now"
+    return AzureQuery.new(@logger, @azure_table_service, @table_name, query_filter, @last_timestamp.to_s + "-" + @until_timestamp.to_s, @entity_count_to_process)
   end
 
   def process(output_queue)
-    if @data_latency_minutes > 0
-      @until_timestamp = (Time.now - (60 * @data_latency_minutes)).iso8601
-      query_filter, query_id = build_latent_query
-    else
-      query_filter, query_id = build_zero_latency_query
+    @until_timestamp = (Time.now - (60 * @data_latency_minutes)).iso8601
+    last_good_timestamp = nil
+
+     # split first query so we don't fetch old data several times for no reason
+    if @first_run
+      @first_run = false
+      diff = DateTime.iso8601(@until_timestamp).to_time - DateTime.iso8601(@last_timestamp).to_time
+      if diff > INITIAL_QUERY_SPLIT_PERIOD_MINUTES * 60
+        @logger.debug("Splitting initial query in two")
+        original_until = @until_timestamp
+
+        @until_timestamp = (DateTime.iso8601(@until_timestamp).to_time - INITIAL_QUERY_SPLIT_PERIOD_MINUTES * 60).iso8601
+
+        query = build_latent_query
+        @duplicate_detector.filter_duplicates(query, ->(entity) {
+          on_new_data(entity, output_queue, last_good_timestamp)
+        }, false)
+
+        @last_timestamp = (DateTime.iso8601(@until_timestamp).to_time - 1).iso8601
+        @until_timestamp = original_until
+      end
     end
 
-    last_good_timestamp = nil
-    query = AzureQuery.new(@logger, @azure_table_service, @table_name, query_filter, query_id, @entity_count_to_process)
-
-    filter_result = @duplicate_detector.filter_duplicates(query,->(entity) {
-      #@logger.debug("new event")
-      event = LogStash::Event.new(entity.properties)
-      event.set("type", @table_name)
-
-      # Help pretty print etw files
-      if (@etw_pretty_print && !event.get("EventMessage").nil? && !event.get("Message").nil?)
-        @logger.debug("event: " + event.to_s)
-        eventMessage = event.get("EventMessage").to_s
-        message = event.get("Message").to_s
-        @logger.debug("EventMessage: " + eventMessage)
-        @logger.debug("Message: " + message)
-        if (eventMessage.include? "%")
-          @logger.debug("starting pretty print")
-          toReplace = eventMessage.scan(/%\d+/)
-          payload = message.scan(/(?<!\\S)([a-zA-Z]+)=(\"[^\"]*\")(?!\\S)/)
-          # Split up the format string to seperate all of the numbers
-          toReplace.each do |key|
-            @logger.debug("Replacing key: " + key.to_s)
-            index = key.scan(/\d+/).join.to_i
-            newValue = payload[index - 1][1]
-            @logger.debug("New Value: " + newValue)
-            eventMessage[key] = newValue
-          end # do block
-          event.set("EventMessage", eventMessage)
-          @logger.debug("pretty print end. result: " + event.get("EventMessage").to_s)
-        end
-      end
-      decorate(event)
-      if event.get('PreciseTimeStamp').is_a?(Time)
-        event.set('PreciseTimeStamp', LogStash::Timestamp.new(event.get('PreciseTimeStamp')))
-      end
-      theTIMESTAMP = event.get('TIMESTAMP')
-      if theTIMESTAMP.is_a?(LogStash::Timestamp)
-        last_good_timestamp = theTIMESTAMP.to_iso8601
-      elsif theTIMESTAMP.is_a?(Time)
-        last_good_timestamp = theTIMESTAMP.iso8601
-        event.set('TIMESTAMP', LogStash::Timestamp.new(theTIMESTAMP))
-      else
-        @logger.warn("Found result with invalid TIMESTAMP. " + event.to_hash.to_s)
-      end
-      output_queue << event
+    query = build_latent_query
+    filter_result = @duplicate_detector.filter_duplicates(query, ->(entity) {
+      last_good_timestamp = on_new_data(entity, output_queue, last_good_timestamp)
     })
 
     if filter_result
@@ -147,13 +120,57 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
       end
     else
       @logger.debug("No new results found.")
-      @last_timestamp = (DateTime.iso8601(@until_timestamp).to_time - 1).iso8601
     end
 
   rescue => e
     @logger.error("Oh My, An error occurred. Error:#{e}: Trace: #{e.backtrace}", :exception => e)
     raise
   end # process
+
+  def on_new_data(entity, output_queue, last_good_timestamp)
+    #@logger.debug("new event")
+    event = LogStash::Event.new(entity.properties)
+    event.set("type", @table_name)
+
+    # Help pretty print etw files
+    if (@etw_pretty_print && !event.get("EventMessage").nil? && !event.get("Message").nil?)
+      @logger.debug("event: " + event.to_s)
+      eventMessage = event.get("EventMessage").to_s
+      message = event.get("Message").to_s
+      @logger.debug("EventMessage: " + eventMessage)
+      @logger.debug("Message: " + message)
+      if (eventMessage.include? "%")
+        @logger.debug("starting pretty print")
+        toReplace = eventMessage.scan(/%\d+/)
+        payload = message.scan(/(?<!\\S)([a-zA-Z]+)=(\"[^\"]*\")(?!\\S)/)
+        # Split up the format string to seperate all of the numbers
+        toReplace.each do |key|
+          @logger.debug("Replacing key: " + key.to_s)
+          index = key.scan(/\d+/).join.to_i
+          newValue = payload[index - 1][1]
+          @logger.debug("New Value: " + newValue)
+          eventMessage[key] = newValue
+        end # do block
+        event.set("EventMessage", eventMessage)
+        @logger.debug("pretty print end. result: " + event.get("EventMessage").to_s)
+      end
+    end
+    decorate(event)
+    if event.get('PreciseTimeStamp').is_a?(Time)
+      event.set('PreciseTimeStamp', LogStash::Timestamp.new(event.get('PreciseTimeStamp')))
+    end
+    theTIMESTAMP = event.get('TIMESTAMP')
+    if theTIMESTAMP.is_a?(LogStash::Timestamp)
+      last_good_timestamp = theTIMESTAMP.to_iso8601
+    elsif theTIMESTAMP.is_a?(Time)
+      last_good_timestamp = theTIMESTAMP.iso8601
+      event.set('TIMESTAMP', LogStash::Timestamp.new(theTIMESTAMP))
+    else
+      @logger.warn("Found result with invalid TIMESTAMP. " + event.to_hash.to_s)
+    end
+    output_queue << event
+    return last_good_timestamp
+  end
 
   # Windows Azure Diagnostic's algorithm for determining the partition key based on time is as follows:
   # 1. Take time in UTC without seconds.
@@ -203,7 +220,7 @@ class AzureQuery
     results_found = false
     @logger.debug("[#{@query_id}]Query filter: " + @query_str)
     begin
-      @logger.debug("[#{@query_id}]Running query. continuation_token=#{@continuation_token}")
+      @logger.debug("[#{@query_id}]Running query. continuation_token: #{@continuation_token}")
       query = { :top => @entity_count_to_process, :filter => @query_str, :continuation_token => @continuation_token }
       result = @azure_table_service.query_entities(@table_name, query)
 
@@ -237,12 +254,11 @@ class QueryData
     uniqueId = ""
     partitionKey = entity.properties["PartitionKey"]
     rowKey = entity.properties["RowKey"]
-    uniqueId << partitionKey << rowKey
+    uniqueId << partitionKey << "#" << rowKey
     return uniqueId
   end
 
-  def run_query
-    results = []
+  def run_query(on_new_entity_cbk)
     @query.reset
     @query.run( ->(entity) {
       uniqueId = get_unique_id(entity)
@@ -251,10 +267,9 @@ class QueryData
         @logger.debug("[#{@query.id}][QueryData] #{uniqueId} already processed")
       else
         @logger.debug("[#{@query.id}][QueryData] #{uniqueId} new item")
-        results.push(entity)
+        on_new_entity_cbk.call(entity)
       end
     })
-    return results
   end
 
   def has_entity(entity)
@@ -270,25 +285,51 @@ class DuplicateDetector
     @query_cache = []
   end
 
-  def filter_duplicates(query, on_new_item_ckb)
+  def filter_duplicates(query, on_new_item_ckb, should_cache_query = true)
+    if query.nil?
+      @logger.debug("query is nil")
+      return false
+    end
     #push in front, pop from the back
     latest_query = QueryData.new(@logger, query)
     @query_cache.insert(0, latest_query)
 
-    #TODO: split first query
     found_new_items = false
 
     # results is most likely empty or has very few items for older queries (most or all should be de-duplicated by run_query)
+    index = 0
     @query_cache.each do |query_data|
-      results = query_data.run_query()
-      results.each do |entity|
-        is_new = true
+        query_data.run_query(->(entity) {
         unique_id = query_data.get_unique_id(entity)
 
-        found_new_items = true
-        @logger.debug("[#{query_data.id}][filter_duplicates] #{unique_id} new item")
-        on_new_item_ckb.call(entity)
-      end
+        # queries overlap. Check for duplicates in all results
+        is_duplicate = false
+        for j in 0..@query_cache.length - 1
+          if j == index
+            next
+          end
+          q = @query_cache[j]
+          if q.has_entity(entity)
+            @logger.debug("[#{query_data.id}][filter_duplicates] #{unique_id} was already processed by #{q.id}")
+            is_duplicate = true
+            break
+          end
+        end
+
+        if !is_duplicate
+          found_new_items = true
+          @logger.debug("[#{query_data.id}][filter_duplicates] #{unique_id} new item")
+          on_new_item_ckb.call(entity)
+        end
+
+      })
+
+      index+=1
+    end
+
+    if !should_cache_query
+      @logger.debug("Removing first item from queue")
+      @query_cache.shift
     end
 
     @logger.debug("Query Cache length: #{@query_cache.length}")

--- a/Logstash/logstash-input-azurewadtable/logstash-input-azurewadtable.gemspec
+++ b/Logstash/logstash-input-azurewadtable/logstash-input-azurewadtable.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-azurewadtable'
-  s.version         = '0.9.11'
+  s.version         = '0.9.12'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This plugin collects Microsoft Azure Diagnostics data from Azure Storage Tables."
   s.description     = "This gem is a Logstash plugin. It reads and parses diagnostics data from Azure Storage Tables."


### PR DESCRIPTION
The biggest problem that Azure Tables with WAD data have is that there's no way of determining what is the point where we left of reading and from where we can pick up. Data can arrive late in a partition that was already read (#23) 
The solution proposed here is to cache the previous queries in a circular buffer (size 5 by default), run them each time and make sure there are no duplicates reported. Of course there's still the chance that data will end up in a partition that is not queried anymore, but the odds are very small and if the data patterns are known, the buffer size can be tweaked.

There are still some issues that are not coverd by this PR, but might be in a future one:
- When the latest query ( PartitionKey > from_ts & PartitionKey < until_ts) returns no data, the next one will include the previous query (PartitionKey > from_Ts & PatitionKey < until_ts + delta). This was the original behaviour, and it's not a big problem, but it means that the DuplicateDetector has to be aware of query overlapping
- When the latest query returns data, the next one will start from the last entity's timestamp, not necessarily from the highest timestamp. This was the original behavior and I didn't want to change it. Maybe there's some logic behind that?
 