### PR TITLE
Fix typo in debug message

### DIFF
--- a/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
+++ b/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
@@ -139,7 +139,7 @@ class LogStash::Inputs::LogstashInputAzureblob < LogStash::Inputs::Base
     # we can abort the loop if stop? becomes true
     while !stop?
       process(queue)
-      @logger.debug("Hitting interval of #{@interval}ms . . .")
+      @logger.debug("Hitting interval of #{@interval}s . . .")
       Stud.stoppable_sleep(@interval) { stop? }
     end # loop
   end # def run


### PR DESCRIPTION
The debug message incorrectly states that the wait is in milliseconds and not in seconds as it should be.