### PR TITLE
Added support for SAS tokens to logstash-input-azurewadtable

### DIFF
--- a/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
+++ b/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
@@ -12,7 +12,8 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
   milestone 1
 
   config :account_name, :validate => :string
-  config :access_key, :validate => :string
+  config :access_key, :validate => :string, :required => false # not required as the sas_token can alternatively be provided
+  config :sas_token, :validate => :string, :required => false # not required as the access_key can alternatively be provided
   config :table_name, :validate => :string
   config :entity_count_to_process, :validate => :string, :default => 100
   config :collection_start_time_utc, :validate => :string, :default => nil #the actual value is set in the ctor (now - data_latency_minutes - 1)
@@ -47,6 +48,7 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
     @client = Azure::Storage::Client.create(
       :storage_account_name => @account_name,
       :storage_access_key => @access_key,
+      :storage_sas_token => @sas_token,
       :storage_table_host => "https://#{@account_name}.table.#{@endpoint}",
       :user_agent_prefix => user_agent)
     @azure_table_service = @client.table_client

--- a/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
+++ b/Logstash/logstash-input-azurewadtable/lib/logstash/inputs/azurewadtable.rb
@@ -45,12 +45,20 @@ class LogStash::Inputs::AzureWADTable < LogStash::Inputs::Base
     user_agent = "logstash-input-azurewadtable"
     user_agent << "/" << Gem.latest_spec_for("logstash-input-azurewadtable").version.to_s
 
-    @client = Azure::Storage::Client.create(
-      :storage_account_name => @account_name,
-      :storage_access_key => @access_key,
-      :storage_sas_token => @sas_token,
-      :storage_table_host => "https://#{@account_name}.table.#{@endpoint}",
-      :user_agent_prefix => user_agent)
+    if @sas_token.nil?
+        @client = Azure::Storage::Client.create(
+        :storage_account_name => @account_name,
+        :storage_access_key => @access_key,
+        :storage_table_host => "https://#{@account_name}.table.#{@endpoint}",
+        :user_agent_prefix => user_agent)
+    else
+      @client = Azure::Storage::Client.create(
+        :storage_account_name => @account_name,
+        :storage_sas_token => @sas_token,
+        :storage_table_host => "https://#{@account_name}.table.#{@endpoint}",
+        :user_agent_prefix => user_agent)
+    end
+
     @azure_table_service = @client.table_client
 
     @last_timestamp = @collection_start_time_utc


### PR DESCRIPTION
Support for SAS Tokens was added to the logstash-input-azurewadtable input plugin.  We are using this in production and wanted to provide an access token that had limited permissions in scope since all this plugin is doing for us is reading from the wadlog tables.