### PR TITLE
Update to official azure-storage-blob package

### DIFF
--- a/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
+++ b/Logstash/logstash-input-azureblob/lib/logstash/inputs/azureblob.rb
@@ -3,7 +3,7 @@ require "logstash/inputs/base"
 require "logstash/namespace"
 
 # Azure Storage SDK for Ruby
-require "azure/storage"
+require "azure/storage/blob"
 require 'json' # for registry content
 require "securerandom" # for generating uuid.
 
@@ -142,11 +142,9 @@ class LogStash::Inputs::LogstashInputAzureblob < LogStash::Inputs::Base
     @reader = SecureRandom.uuid
 
     # Setup a specific instance of an Azure::Storage::Client
-    client = Azure::Storage::Client.create(:storage_account_name => @storage_account_name, :storage_access_key => @storage_access_key, :storage_blob_host => "https://#{@storage_account_name}.blob.#{@endpoint}", :user_agent_prefix => user_agent)
-    # Get an azure storage blob service object from a specific instance of an Azure::Storage::Client
-    @azure_blob = client.blob_client
+    @azure_blob = Azure::Storage::Blob::BlobService.create(:storage_account_name => @storage_account_name, :storage_access_key => @storage_access_key, :storage_blob_host => "https://#{@storage_account_name}.blob.#{@endpoint}", :user_agent_prefix => user_agent)
     # Add retry filter to the service object
-    @azure_blob.with_filter(Azure::Storage::Core::Filter::ExponentialRetryPolicyFilter.new)
+    @azure_blob.with_filter(Azure::Storage::Common::Core::Filter::ExponentialRetryPolicyFilter.new)
   end # def register
 
   def run(queue)

--- a/Logstash/logstash-input-azureblob/logstash-input-azureblob.gemspec
+++ b/Logstash/logstash-input-azureblob/logstash-input-azureblob.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
   s.add_runtime_dependency 'logstash-codec-json_lines', '~> 3'
   s.add_runtime_dependency 'stud', '~> 0.0', '>= 0.0.22'
-  s.add_runtime_dependency 'azure-storage', '~> 0.15.0.preview'
+  s.add_runtime_dependency 'azure-storage-blob', '~> 2'
   s.add_development_dependency 'logstash-devutils', '~> 1'
   s.add_development_dependency 'logging', '~> 2'
 


### PR DESCRIPTION
The preview version is outdated, and it depends on an old version of faraday, which is not compatible with elastic 7.15.